### PR TITLE
Removed s from "lights openhab:" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ switch openhab:
 
 Control openhab dimmers as lights in homeassistant
 ```yml
-lights openhab:
+light openhab:
   platform: openhab
   host: http://127.0.0.1:8080
 ```


### PR DESCRIPTION
Noticed there was an s and the end of lights openhab: in the README.md so I figured I could fix it instead of just pointing it out. Also thanks for this component!